### PR TITLE
Update Index.js to support hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports.prototype.apply = function(compiler) {
 
             // Look for purifyable CSs...
             for(var key in compilation.assets) {
-                if(/\.css$/i.test(key)) {
+                if(/\.css/i.test(key)) {
                     // We found a CSS. So purify it.
                     var asset = compilation.assets[key];
                     var css = asset.source();


### PR DESCRIPTION
i'm using hash from ExtractTextPlugin so my css file name looks like : "styles.css?[contenthash]",
therefore i needed to change the regex.